### PR TITLE
Suggest update to pom.xml for UTF-8 enocding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,13 @@
   <groupId>com.mediasift</groupId>
   <artifactId>datasift-java</artifactId>
   <packaging>jar</packaging>
+
+  <!-- specify encoding to hush up maven -->
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
   <version>1.3.4</version>
 
   <name>DataSift Java Client library</name>


### PR DESCRIPTION
Noted that the pom.xml file did not specify a content encoding, adding the lines in this pull request will make the project compile without so many warnings about assumptions of the build machine.
