### PR TITLE
Overloaded methods to provided a convenient way to fall back if the object is not found in the json tree

### DIFF
--- a/src/org/datasift/JSONdn.java
+++ b/src/org/datasift/JSONdn.java
@@ -81,6 +81,20 @@ public class JSONdn extends JSONObject {
 					+ "\") does not exist");
 		}
 	}
+	
+	/**
+	 * Get a boolean value or falls back to the default provided if not found
+	 * @param key
+	 * @param defaultVal
+	 * @return
+	 */
+	public boolean getBooleanVal(String key, boolean defaultVal) {
+		try {
+			return (this.has(key)) ? this.getBooleanVal(key) : defaultVal;
+		} catch (EInvalidData e) {
+			throw new RuntimeException("Key (\""+key+"\") allegedly present but value not found");
+		}
+	}
 
 	/**
 	 * Get a double value.
@@ -98,6 +112,20 @@ public class JSONdn extends JSONObject {
 		} catch (JSONException e) {
 			throw new EInvalidData("Requested key (\"" + key
 					+ "\") does not exist");
+		}
+	}
+	
+	/**
+	 * Get a double value or falls back to the default provided if not found
+	 * @param key
+	 * @param defaultVal
+	 * @return
+	 */
+	public double getDoubleVal(String key, double defaultVal) {
+		try {
+			return (this.has(key)) ? this.getDoubleVal(key) : defaultVal;
+		} catch (EInvalidData e) {
+			throw new RuntimeException("Key (\""+key+"\") allegedly present but value not found");
 		}
 	}
 
@@ -119,6 +147,20 @@ public class JSONdn extends JSONObject {
 					+ "\") does not exist");
 		}
 	}
+	
+	/**
+	 * Get a int value or falls back to the default provided if not found
+	 * @param key
+	 * @param defaultVal
+	 * @return
+	 */
+	public int getIntVal(String key, int defaultVal) {
+		try {
+			return (this.has(key)) ? this.getIntVal(key) : defaultVal;
+		} catch (EInvalidData e) {
+			throw new RuntimeException("Key (\""+key+"\") allegedly present but value not found");
+		}
+	}
 
 	/**
 	 * Get a long value.
@@ -138,6 +180,20 @@ public class JSONdn extends JSONObject {
 					+ "\") does not exist");
 		}
 	}
+	
+	/**
+	 * Get a long value or falls back to the default provided if not found
+	 * @param key
+	 * @param defaultVal
+	 * @return
+	 */
+	public long getLongVal(String key, long defaultVal) {
+		try {
+			return (this.has(key)) ? this.getLongVal(key) : defaultVal;
+		} catch (EInvalidData e) {
+			throw new RuntimeException("Key (\""+key+"\") allegedly present but value not found");
+		}
+	}
 
 	/**
 	 * Get a string value.
@@ -155,6 +211,20 @@ public class JSONdn extends JSONObject {
 		} catch (JSONException e) {
 			throw new EInvalidData("Requested key (\"" + key
 					+ "\") does not exist");
+		}
+	}
+	
+	/**
+	 * Get a String value or falls back to the default provided if not found
+	 * @param key
+	 * @param defaultVal
+	 * @return
+	 */
+	public String getStringVal(String key, String defaultVal) {
+		try {
+			return (this.has(key)) ? this.getStringVal(key) : defaultVal;
+		} catch (EInvalidData e) {
+			throw new RuntimeException("Key (\""+key+"\") allegedly present but value not found");
 		}
 	}
 


### PR DESCRIPTION
Hi, we're using the api and found that this could be very helpful since those methods are exposed to the client via _"org.datasift.Interaction.java"_.

The idea is to have a simple "safe" _getStringVal(key, defaultValue)_ that wont throw a _"EInvalidData"_ exception. All the main methods were overloaded. _(getBooleanVal, getDoubleVal, getIntVal, getLongVal, getStringVal)_ 

It makes use of the provided _has(String key)_ method before attempting the
getter on the json object, if still the object was not found then it throws a RuntimeException explaining the issue.
