### PR TITLE
Updated docs links, delivery_frequency values and max_size values

### DIFF
--- a/src/main/java/com/datasift/client/push/connectors/FTP.java
+++ b/src/main/java/com/datasift/client/push/connectors/FTP.java
@@ -3,7 +3,7 @@ package com.datasift.client.push.connectors;
 import com.datasift.client.push.OutputType;
 
 /**
- * <a href="http://dev.datasift.com/docs/push/connectors/couchdb">Official docs</a>
+ * <a href="http://dev.datasift.com/docs/push/connectors/ftp">Official docs</a>
  *
  * @author Courtney Robinson <courtney.robinson@datasift.com>
  */
@@ -86,17 +86,21 @@ public class FTP extends BaseConnector<FTP> {
     /**
      * The minimum number of seconds you want DataSift to wait before sending data again:
      * <p/>
+     * 10 (10 seconds)
+     * <p/>
+     * 30 (30 seconds)
+     * <p/>
      * 60 (1 minute)
+     * <p/>
+     * 120 (2 minutes)
      * <p/>
      * 300 (5 minutes)
      * <p/>
-     * 900 (15 minutes)
-     * <p/>
      * In reality, a stream might not have data available after the wait. Typically this happens in streams that have
      * very tight filtering constraints, so the wait time might be longer than you specify. If your system is capable
-     * of handling large amounts of incoming data, you can turn on continuous delivery:
+     * of handling large amounts of incoming data, we recommend you use continuous delivery:
      * <p/>
-     * 0  (continuous delivery)
+     * 0 (continuous delivery)
      *
      * @return this
      */
@@ -106,22 +110,17 @@ public class FTP extends BaseConnector<FTP> {
 
     /**
      * The maximum amount of data that DataSift will send in a single batch:
-     * <p/>
      * 102400 (100KB)
-     * <p/>
      * 256000 (250KB)
-     * <p/>
      * 512000 (500KB)
-     * <p/>
      * 1048576 (1MB)
-     * <p/>
      * 2097152 (2MB)
-     * <p/>
      * 5242880 (5MB)
-     * <p/>
      * 10485760 (10MB)
-     * <p/>
      * 20971520 (20MB)
+     * 52428800 (50MB)
+     * 104857600 (100MB)
+     * 209715200 (200MB)
      *
      * @return this
      */

--- a/src/main/java/com/datasift/client/push/connectors/Http.java
+++ b/src/main/java/com/datasift/client/push/connectors/Http.java
@@ -4,7 +4,7 @@ import com.datasift.client.push.OutputType;
 import io.netty.handler.codec.http.HttpMethod;
 
 /**
- * <a href="http://dev.datasift.com/docs/push/connectors/couchdb">Official docs</a>
+ * <a href="http://dev.datasift.com/docs/push/connectors/http">Official docs</a>
  *
  * @author Courtney Robinson <courtney.robinson@datasift.com>
  */
@@ -95,17 +95,21 @@ public class Http extends BaseConnector<Http> {
     /**
      * The minimum number of seconds you want DataSift to wait before sending data again:
      * <p/>
+     * 10 (10 seconds)
+     * <p/>
+     * 30 (30 seconds)
+     * <p/>
      * 60 (1 minute)
+     * <p/>
+     * 120 (2 minutes)
      * <p/>
      * 300 (5 minutes)
      * <p/>
-     * 900 (15 minutes)
-     * <p/>
      * In reality, a stream might not have data available after the wait. Typically this happens in streams that have
      * very tight filtering constraints, so the wait time might be longer than you specify. If your system is capable
-     * of handling large amounts of incoming data, you can turn on continuous delivery:
+     * of handling large amounts of incoming data, we recommend you use continuous delivery:
      * <p/>
-     * 0  (continuous delivery)
+     * 0 (continuous delivery)
      *
      * @return this
      */
@@ -115,22 +119,17 @@ public class Http extends BaseConnector<Http> {
 
     /**
      * The maximum amount of data that DataSift will send in a single batch:
-     * <p/>
      * 102400 (100KB)
-     * <p/>
      * 256000 (250KB)
-     * <p/>
      * 512000 (500KB)
-     * <p/>
      * 1048576 (1MB)
-     * <p/>
      * 2097152 (2MB)
-     * <p/>
      * 5242880 (5MB)
-     * <p/>
      * 10485760 (10MB)
-     * <p/>
      * 20971520 (20MB)
+     * 52428800 (50MB)
+     * 104857600 (100MB)
+     * 209715200 (200MB)
      *
      * @return this
      */

--- a/src/main/java/com/datasift/client/push/connectors/S3.java
+++ b/src/main/java/com/datasift/client/push/connectors/S3.java
@@ -58,15 +58,14 @@ public class S3 extends BaseConnector<S3> {
 
     /**
      * The minimum number of seconds you want DataSift to wait before sending data again:
+     * 0 (continuous delivery)
      * 10 (10 seconds)
      * 30 (30 seconds)
      * 60 (1 minute)
      * 300 (5 minutes)
-     * 900 (15 minutes)
      * In reality, a stream might not have data available after the wait. Typically this happens in streams that have
-     * very tight filtering constraints, so the wait time might be longer than you specify. If your system is capable
-     * of handling large amounts of incoming data, you can turn on continuous delivery:
-     * 0  (continuous delivery)
+     * very tight filtering constraints, so the wait time might be longer than you specify. Amazon's S3 is capable
+     * of handling large amounts of incoming data, so we recommend you use continuous delivery.
      *
      * @param frequency an int representative of what is desribed above
      * @return this
@@ -85,6 +84,9 @@ public class S3 extends BaseConnector<S3> {
      * 5242880 (5MB)
      * 10485760 (10MB)
      * 20971520 (20MB)
+     * 52428800 (50MB)
+     * 104857600 (100MB)
+     * 209715200 (200MB)
      *
      * @param maxSize max size as described
      * @return this

--- a/src/main/java/com/datasift/client/push/connectors/SFTP.java
+++ b/src/main/java/com/datasift/client/push/connectors/SFTP.java
@@ -52,17 +52,21 @@ public class SFTP extends BaseConnector<SFTP> {
     /**
      * The minimum number of seconds you want DataSift to wait before sending data again:
      * <p/>
+     * 10 (10 seconds)
+     * <p/>
+     * 30 (30 seconds)
+     * <p/>
      * 60 (1 minute)
+     * <p/>
+     * 120 (2 minutes)
      * <p/>
      * 300 (5 minutes)
      * <p/>
-     * 900 (15 minutes)
-     * <p/>
      * In reality, a stream might not have data available after the wait. Typically this happens in streams that have
      * very tight filtering constraints, so the wait time might be longer than you specify. If your system is capable
-     * of handling large amounts of incoming data, you can turn on continuous delivery:
+     * of handling large amounts of incoming data, we recommend you use continuous delivery:
      * <p/>
-     * 0  (continuous delivery)
+     * 0 (continuous delivery)
      *
      * @return this
      */
@@ -72,22 +76,17 @@ public class SFTP extends BaseConnector<SFTP> {
 
     /**
      * The maximum amount of data that DataSift will send in a single batch:
-     * <p/>
      * 102400 (100KB)
-     * <p/>
      * 256000 (250KB)
-     * <p/>
      * 512000 (500KB)
-     * <p/>
      * 1048576 (1MB)
-     * <p/>
      * 2097152 (2MB)
-     * <p/>
      * 5242880 (5MB)
-     * <p/>
      * 10485760 (10MB)
-     * <p/>
      * 20971520 (20MB)
+     * 52428800 (50MB)
+     * 104857600 (100MB)
+     * 209715200 (200MB)
      *
      * @return this
      */

--- a/src/main/java/com/datasift/client/push/connectors/SplunkEnterprise.java
+++ b/src/main/java/com/datasift/client/push/connectors/SplunkEnterprise.java
@@ -3,7 +3,7 @@ package com.datasift.client.push.connectors;
 import com.datasift.client.push.OutputType;
 
 /**
- * <a href="http://dev.datasift.com/docs/push/connectors/couchdb">Official docs</a>
+ * <a href="http://dev.datasift.com/docs/push/connectors/splunk-enterprise">Official docs</a>
  *
  * @author Courtney Robinson <courtney.robinson@datasift.com>
  */

--- a/src/main/java/com/datasift/client/push/connectors/SplunkStorm.java
+++ b/src/main/java/com/datasift/client/push/connectors/SplunkStorm.java
@@ -3,7 +3,7 @@ package com.datasift.client.push.connectors;
 import com.datasift.client.push.OutputType;
 
 /**
- * <a href="http://dev.datasift.com/docs/push/connectors/couchdb">Official docs</a>
+ * <a href="http://dev.datasift.com/docs/push/connectors/splunk-storm">Official docs</a>
  *
  * @author Courtney Robinson <courtney.robinson@datasift.com>
  */

--- a/src/main/java/com/datasift/client/push/connectors/SplunkStormRest.java
+++ b/src/main/java/com/datasift/client/push/connectors/SplunkStormRest.java
@@ -3,7 +3,7 @@ package com.datasift.client.push.connectors;
 import com.datasift.client.push.OutputType;
 
 /**
- * <a href="http://dev.datasift.com/docs/push/connectors/couchdb">Official docs</a>
+ * <a href="http://dev.datasift.com/docs/push/connectors/splunk-storm-rest">Official docs</a>
  *
  * @author Courtney Robinson <courtney.robinson@datasift.com>
  */

--- a/src/main/java/com/datasift/client/push/connectors/ZoomData.java
+++ b/src/main/java/com/datasift/client/push/connectors/ZoomData.java
@@ -3,7 +3,7 @@ package com.datasift.client.push.connectors;
 import com.datasift.client.push.OutputType;
 
 /**
- * <a href="http://dev.datasift.com/docs/push/connectors/couchdb">Official docs</a>
+ * <a href="http://dev.datasift.com/docs/push/connectors/zoomdata">Official docs</a>
  *
  * @author Courtney Robinson <courtney.robinson@datasift.com>
  */


### PR DESCRIPTION
- Updated links to official connector docs (they were wrong in some cases)
- Updated documented delivery_frequency values - max is now 300 (5 minutes)
- Updated max_size values - max is now 200M in some cases
- Changes wording to recommend continuous delivery (because it rocks)
