### PR TITLE
Dot Notation ends early

### DIFF
--- a/src/main/java/com/datasift/client/stream/Interaction.java
+++ b/src/main/java/com/datasift/client/stream/Interaction.java
@@ -37,7 +37,7 @@ public class Interaction {
     public JsonNode get(String str) {
         String[] parts = str.split("\\.");
         JsonNode retval = data.get(parts[0]);
-        for (int i = 1; i < parts.length - 1; i++) {
+        for (int i = 1; i <= parts.length - 1; i++) {
             if (retval == null) {
                 return null;
             } else {


### PR DESCRIPTION
The example twitter object, the field id won't be reached. String[] parts returns length of 3 and the for loop starts at 1

First iteration: i = 1; 1 < 2 (true,continue in loop)
Second iteration: i =2; 2 < 2 (false, don't enter loop)

parts[2] is the "id" of the object. In order to not exit the loop early we need to evaluate 
i <= (parts.length - 1)
or
i < parts.length
