### PR TITLE
pom.xml: Update high-scale-lib to 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.boundary</groupId>
             <artifactId>high-scale-lib</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.6</version>
         </dependency>
         <dependency>
             <groupId>io.higgs</groupId>


### PR DESCRIPTION
Use high-scale-lib 1.0.6 since it's only available version in Maven Central.
This fixes #58 issue.
