### PR TITLE
Make the dead connection detection thread a daemon thread.

### DIFF
--- a/src/main/java/com/datasift/client/stream/ConnectionManager.java
+++ b/src/main/java/com/datasift/client/stream/ConnectionManager.java
@@ -45,7 +45,7 @@ public class ConnectionManager {
             return;
         }
         final Logger log = LoggerFactory.getLogger(ConnectionManager.class);
-        new Thread(new Runnable() {
+        Thread deadConnThread = new Thread(new Runnable() {
             public void run() {
                 CONNECTION_DETECTOR_RUNNING = true;
                 try {
@@ -73,7 +73,9 @@ public class ConnectionManager {
                     CONNECTION_DETECTOR_RUNNING = false;
                 }
             }
-        }, "dead-connections-monitor").start();
+        }, "dead-connections-monitor");
+        deadConnThread.setDaemon(true);
+        deadConnThread.start();
     }
 
     public ConnectionManager(DataSiftConfig config) {


### PR DESCRIPTION
Currently ConnectionManager statically instantiates a "dead-connections-monitor" thread as a non-daemon thread which prevents processes from exiting in a normal fashion. I believe this static instantiation - with no lifecycle hooks!!! - needs to be rethought, but as a decent workaround marking the thread as daemon should suffice. 