### PR TITLE
fix pylon stop, contd.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,12 @@
             <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/main/java/com/datasift/client/pylon/DataSiftPylon.java
+++ b/src/main/java/com/datasift/client/pylon/DataSiftPylon.java
@@ -162,14 +162,14 @@ public class DataSiftPylon extends DataSiftApiClient {
      * or using {@link com.datasift.client.BaseDataSiftResult#isSuccessful()}
      */
     public FutureData<DataSiftResult> stop(PylonRecordingId recordingId) {
-        if (recordingId == null || recordingId.id == null || recordingId.id.isEmpty()) {
+        if (recordingId == null || recordingId.getId() == null || recordingId.getId().isEmpty()) {
             throw new IllegalArgumentException("A valid recording id is required to stop a recording");
         }
         FutureData<DataSiftResult> future = new FutureData<>();
         URI uri = newParams().forURL(config.newAPIEndpointURI(STOP));
         JSONRequest request = config.http()
                 .putJSON(uri, new PageReader(newRequestCallback(future, new BaseDataSiftResult(), config)))
-                .addField("id", recordingId);
+                .addField("id", recordingId.getId());
         performRequest(future, request);
         return future;
     }

--- a/src/test/java/com/datasift/client/mock/TestPylonApiWithMocks.java
+++ b/src/test/java/com/datasift/client/mock/TestPylonApiWithMocks.java
@@ -1,6 +1,8 @@
 package com.datasift.client.mock;
 
 import com.datasift.client.DataSiftResult;
+import com.datasift.client.FutureData;
+import com.datasift.client.FutureResponse;
 import com.datasift.client.IntegrationTestBase;
 import com.datasift.client.pylon.PylonSample;
 import com.datasift.client.pylon.PylonSampleInteraction;
@@ -18,6 +20,7 @@ import io.higgs.core.ObjectFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -158,6 +161,15 @@ public class TestPylonApiWithMocks extends IntegrationTestBase {
     @Test
     public void testIfUserCanStopDataStream() {
         DataSiftResult stop = datasift.pylon().stop(new PylonRecordingId(recordingId)).sync();
+        assertTrue(stop.isSuccessful());
+    }
+
+    @Test
+    public void testIfUserCanStopDataStreamAndItReadsId() {
+        PylonRecordingId rid = mock(PylonRecordingId.class);
+        when(rid.getId()).thenReturn(recordingId);
+        DataSiftResult stop = datasift.pylon().stop(rid).sync();
+        verify(rid, times(3)).getId();
         assertTrue(stop.isSuccessful());
     }
 


### PR DESCRIPTION
* pylon stop was sending a stop with `{"id": "foo"}` rather than `foo`
as the recording ID
* changed stop() to pull the recording ID out correctly
* depended on mockito for tests
* added a test with mockito to ensure the ID is extracted correctly