### PR TITLE
ENG-5244 implement Pylon Task API Support

### DIFF
--- a/src/main/java/com/datasift/client/DataSiftConfig.java
+++ b/src/main/java/com/datasift/client/DataSiftConfig.java
@@ -259,8 +259,9 @@ public class DataSiftConfig {
      * Force the client to use a version other than the default.
      * @param prefix the prefix to use, this should be along the lines of v1.3 i.e. vMajor.Minor
      */
-    public void versionPrefix(String prefix) {
+    public DataSiftConfig versionPrefix(String prefix) {
         versionPrefix = prefix;
+        return this;
     }
 
     public String getUsername() {

--- a/src/main/java/com/datasift/client/pylon/DataSiftPylonTask.java
+++ b/src/main/java/com/datasift/client/pylon/DataSiftPylonTask.java
@@ -1,0 +1,67 @@
+package com.datasift.client.pylon;
+
+import com.datasift.client.DataSiftApiClient;
+import com.datasift.client.DataSiftConfig;
+import com.datasift.client.FutureData;
+import com.datasift.client.ParamBuilder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.higgs.http.client.JSONRequest;
+import io.higgs.http.client.Request;
+import io.higgs.http.client.readers.PageReader;
+
+import java.net.URI;
+
+/**
+ * This class provides access to the DataSift Analysis Task API.
+ */
+public class DataSiftPylonTask extends DataSiftApiClient {
+    protected static final String service = "linkedin";
+
+    public final String TASK = "pylon/linkedin/task/";
+
+    public DataSiftPylonTask(DataSiftConfig config) {
+        super(config);
+    }
+
+    public FutureData<PylonTaskResultList> get(int page, int perPage) {
+        FutureData<PylonTaskResultList> future = new FutureData<>();
+        ParamBuilder b = new ParamBuilder();
+        if (page > 0) {
+            b.put("page", page);
+        }
+        if (perPage > 0) {
+            b.put("per_page", perPage);
+        }
+        URI uri = b.forURL(config.newAPIEndpointURI(TASK));
+        Request request = config.http().GET(uri,
+                new PageReader(newRequestCallback(future, new PylonTaskResultList(), config)));
+        performRequest(future, request);
+        return future;
+    }
+
+    public FutureData<PylonTaskResult> get(String id) {
+        URI uri = newParams().forURL(config.newAPIEndpointURI(TASK + id));
+        FutureData<PylonTaskResult> future = new FutureData<>();
+        Request request = config.http().GET(uri,
+                new PageReader(newRequestCallback(future, new PylonTaskResult(), config)));
+        performRequest(future, request);
+        return future;
+    }
+
+    public FutureData<PylonTaskResult> analyze(PylonTaskRequest query) {
+        if (query == null) {
+            throw new IllegalArgumentException("A valid analyze request body is required to analyze a stream");
+        }
+        FutureData<PylonTaskResult> future = new FutureData<PylonTaskResult>();
+        URI uri = newParams().forURL(config.newAPIEndpointURI(TASK));
+        try {
+            JSONRequest result = config.http()
+                    .postJSON(uri, new PageReader(newRequestCallback(future, new PylonTaskResult(), config)))
+                    .setData(query);
+            performRequest(future, result);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Valid JSON is required to analyze a stream");
+        }
+        return future;
+    }
+}

--- a/src/main/java/com/datasift/client/pylon/DataSiftPylonTask.java
+++ b/src/main/java/com/datasift/client/pylon/DataSiftPylonTask.java
@@ -48,15 +48,15 @@ public class DataSiftPylonTask extends DataSiftApiClient {
         return future;
     }
 
-    public FutureData<PylonTaskResult> analyze(PylonTaskRequest query) {
+    public FutureData<PylonTaskAnalyzeResponse> analyze(PylonTaskRequest query) {
         if (query == null) {
             throw new IllegalArgumentException("A valid analyze request body is required to analyze a stream");
         }
-        FutureData<PylonTaskResult> future = new FutureData<PylonTaskResult>();
+        FutureData<PylonTaskAnalyzeResponse> future = new FutureData<PylonTaskAnalyzeResponse>();
         URI uri = newParams().forURL(config.newAPIEndpointURI(TASK));
         try {
             JSONRequest result = config.http()
-                    .postJSON(uri, new PageReader(newRequestCallback(future, new PylonTaskResult(), config)))
+                    .postJSON(uri, new PageReader(newRequestCallback(future, new PylonTaskAnalyzeResponse(), config)))
                     .setData(query);
             performRequest(future, result);
         } catch (JsonProcessingException ex) {

--- a/src/main/java/com/datasift/client/pylon/PylonParametersData.java
+++ b/src/main/java/com/datasift/client/pylon/PylonParametersData.java
@@ -19,6 +19,11 @@ public class PylonParametersData {
 
     public PylonParametersData() { }
 
+    public PylonParametersData(String target, Integer threshold) {
+        this.threshold = threshold;
+        this.target = target;
+    }
+
     public PylonParametersData(String interval, Float span, Integer threshold, String target) {
         this.interval = interval;
         this.target = target;

--- a/src/main/java/com/datasift/client/pylon/PylonTask.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTask.java
@@ -1,0 +1,66 @@
+package com.datasift.client.pylon;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PylonTask {
+    @JsonProperty("subscription_id")
+    protected String subscriptionId;
+
+    @JsonProperty
+    protected PylonTaskParameters parameters;
+
+    @JsonProperty
+    protected String type;
+
+    @JsonProperty("created_at")
+    protected long createdAt;
+
+    @JsonProperty("updated_at")
+    protected long updatedAt;
+
+    @JsonProperty("id")
+    protected String id;
+
+    @JsonProperty("id")
+    protected String status;
+
+    public PylonTask() {
+    }
+
+    public PylonTask(String subscriptionId,
+                     PylonTaskParameters parameters,
+                     String type) {
+        this.subscriptionId = subscriptionId;
+        this.parameters = parameters;
+        this.type = type;
+    }
+
+    public String getRecordingId() {
+        return this.subscriptionId;
+    }
+
+    public PylonTaskParameters getParameters() {
+        return this.parameters;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public long getCreatedAt() {
+        return this.createdAt;
+    }
+
+    public long getUpdatedAt() {
+        return this.updatedAt;
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskAnalysisResult.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskAnalysisResult.java
@@ -1,0 +1,39 @@
+package com.datasift.client.pylon;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PylonTaskAnalysisResult {
+    @JsonProperty("analysis_type")
+    protected String analysisType;
+
+    @JsonProperty
+    protected PylonParametersData parameters;
+
+    @JsonProperty
+    protected boolean redacted;
+
+    @JsonProperty
+    protected List<PylonTaskAnalysisResultBucket> results = new ArrayList<PylonTaskAnalysisResultBucket>();
+
+    public PylonTaskAnalysisResult() {
+    }
+
+    public String getAnalysisType() {
+        return this.analysisType;
+    }
+
+    public PylonParametersData getParameters() {
+        return this.parameters;
+    }
+
+    public boolean getRedacted() {
+        return this.redacted;
+    }
+
+    public List<PylonTaskAnalysisResultBucket> getResults() {
+        return this.results;
+    }
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskAnalysisResultBucket.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskAnalysisResultBucket.java
@@ -1,0 +1,32 @@
+package com.datasift.client.pylon;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PylonTaskAnalysisResultBucket {
+    @JsonProperty
+    protected long interactions;
+
+    @JsonProperty("unique_authors")
+    protected long uniqueAuthors;
+
+    @JsonProperty
+    protected String key;
+
+    public PylonTaskAnalysisResultBucket() {
+    }
+
+    public long getInteractions() {
+        return this.interactions;
+    }
+
+    public long getUniqueAuthors() {
+        return this.uniqueAuthors;
+    }
+
+    public String getKey() {
+        return this.key;
+    }
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskAnalyzeResponse.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskAnalyzeResponse.java
@@ -1,0 +1,18 @@
+package com.datasift.client.pylon;
+
+import com.datasift.client.BaseDataSiftResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PylonTaskAnalyzeResponse extends BaseDataSiftResult {
+
+    public PylonTaskAnalyzeResponse() {
+    }
+
+    @JsonProperty
+    protected String id;
+
+    public String getId() {
+        return id;
+    }
+
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskParameters.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskParameters.java
@@ -1,0 +1,93 @@
+package com.datasift.client.pylon;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PylonTaskParameters {
+    @JsonProperty
+    protected PylonQueryParameters parameters;
+
+    @JsonProperty("child")
+    protected PylonTaskParametersChild childAnalysis;
+
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    protected int start;
+
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    protected int end;
+
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    protected String filter;
+
+    public PylonTaskParameters() {
+    }
+
+    public PylonTaskParameters(PylonQueryParameters parameters, Integer start, Integer end) {
+        this.parameters = parameters;
+        if (start != null) {
+            this.start = start;
+        }
+        if (end != null) {
+            this.end = end;
+        }
+    }
+
+    public PylonTaskParameters(PylonQueryParameters parameters, Integer start, Integer end, String filter) {
+        this.parameters = parameters;
+        if (start != null) {
+            this.start = start;
+        }
+        if (end != null) {
+            this.end = end;
+        }
+        if (filter != null) {
+            this.filter = filter;
+        }
+    }
+
+    public PylonTaskParameters(String analysisType,
+                               PylonQueryParameters parameters,
+                               PylonTaskParametersChild child,
+                               Integer start,
+                               Integer end) {
+        this.parameters = parameters;
+        this.childAnalysis = child;
+        if (start != null) {
+            this.start = start;
+        }
+        if (end != null) {
+            this.end = end;
+        }
+    }
+
+    public PylonQueryParameters getParameters() {
+        return this.parameters;
+    }
+
+    public PylonTaskParametersChild getChildAnalysis() {
+        return this.childAnalysis;
+    }
+
+    public void setParameters(PylonQueryParameters parameters) {
+        this.parameters = parameters;
+    }
+
+    public void setChildAnalysis(PylonTaskParametersChild childAnalysis) {
+        this.childAnalysis = childAnalysis;
+    }
+
+    public int getStart() {
+        return this.start;
+    }
+
+    public int getEnd() {
+        return this.end;
+    }
+
+    public String getFilter() {
+        return this.filter;
+    }
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskParametersChild.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskParametersChild.java
@@ -1,0 +1,56 @@
+package com.datasift.client.pylon;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PylonTaskParametersChild {
+    @JsonProperty("analysis_type")
+    protected String analysisType;
+    @JsonProperty
+    protected PylonParametersData parameters;
+    @JsonProperty("child")
+    protected PylonTaskParametersChild childAnalysis;
+
+    public PylonTaskParametersChild() {
+    }
+
+    public PylonTaskParametersChild(String analysisType, PylonParametersData parameters, Integer start, Integer end) {
+        this.analysisType = analysisType;
+        this.parameters = parameters;
+    }
+
+    public PylonTaskParametersChild(String analysisType,
+                                    PylonParametersData parameters,
+                                    PylonTaskParametersChild child,
+                                    Integer start,
+                                    Integer end) {
+        this.analysisType = analysisType;
+        this.parameters = parameters;
+        this.childAnalysis = child;
+    }
+
+    public String getAnalysisType() {
+        return this.analysisType;
+    }
+
+    public PylonParametersData getParameters() {
+        return this.parameters;
+    }
+
+    public PylonTaskParametersChild getChildAnalysis() {
+        return this.childAnalysis;
+    }
+
+    public void setAnalysisType(String analysisType) {
+        this.analysisType = analysisType;
+    }
+
+    public void setParameters(PylonParametersData parameters) {
+        this.parameters = parameters;
+    }
+
+    public void setChildAnalysis(PylonTaskParametersChild childAnalysis) {
+        this.childAnalysis = childAnalysis;
+    }
+
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskRequest.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskRequest.java
@@ -1,0 +1,52 @@
+package com.datasift.client.pylon;
+
+import com.datasift.client.pylon.PylonRecording.PylonRecordingId;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+public class PylonTaskRequest {
+    @JsonProperty("subscription_id")
+    protected String subscriptionId;
+
+    @JsonProperty
+    protected PylonTaskParameters parameters;
+
+    @JsonProperty
+    protected String name;
+
+    @JsonProperty
+    protected String type;
+
+    public PylonTaskRequest() {
+    }
+
+    public PylonTaskRequest(String subscriptionId,
+                            PylonTaskParameters parameters,
+                            String name,
+                            String type) {
+        this.subscriptionId = subscriptionId;
+        this.parameters = parameters;
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getRecordingId() {
+        return this.subscriptionId;
+    }
+
+    public PylonTaskParameters getParameters() {
+        return this.parameters;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskResult.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskResult.java
@@ -1,0 +1,81 @@
+package com.datasift.client.pylon;
+
+import com.datasift.client.BaseDataSiftResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PylonTaskResult extends BaseDataSiftResult {
+
+    public PylonTaskResult() {
+    }
+
+    @JsonProperty
+    protected String id;
+
+    @JsonProperty("identity_id")
+    protected String identityId;
+
+    @JsonProperty("subscription_id")
+    protected String subscriptionId;
+
+    @JsonProperty
+    protected String name;
+
+    @JsonProperty
+    protected String type;
+
+    @JsonProperty
+    protected PylonTaskParameters parameters;
+
+    @JsonProperty
+    protected PylonTaskResultResult result;
+
+    @JsonProperty
+    protected String status;
+
+    @JsonProperty("created_at")
+    protected int createdAt;
+
+    @JsonProperty("updated_at")
+    protected int updatedAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIdentityId() {
+        return identityId;
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public PylonTaskParameters getParameters() {
+        return parameters;
+    }
+
+    public PylonTaskResultResult getResult() {
+        return result;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public int getCreatedAt() {
+        return createdAt;
+    }
+
+    public int getUpdatedAt() {
+        return updatedAt;
+    }
+
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskResultList.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskResultList.java
@@ -1,0 +1,43 @@
+package com.datasift.client.pylon;
+
+import com.datasift.client.BaseDataSiftResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PylonTaskResultList extends BaseDataSiftResult {
+    @JsonProperty
+    protected List<PylonTaskResult> tasks = new ArrayList<PylonTaskResult>();
+    @JsonProperty
+    protected int count;
+    @JsonProperty
+    protected int page;
+    @JsonProperty("per_page")
+    protected int perPage;
+    @JsonProperty
+    protected int pages;
+
+    public PylonTaskResultList() {
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public List<PylonTaskResult> getTasks() {
+        return tasks;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getPerPage() {
+        return perPage;
+    }
+
+    public int getPages() {
+        return pages;
+    }
+}

--- a/src/main/java/com/datasift/client/pylon/PylonTaskResultResult.java
+++ b/src/main/java/com/datasift/client/pylon/PylonTaskResultResult.java
@@ -1,0 +1,31 @@
+package com.datasift.client.pylon;
+
+import com.datasift.client.BaseDataSiftResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PylonTaskResultResult {
+    @JsonProperty("analysis")
+    protected PylonTaskAnalysisResult analysis;
+
+    @JsonProperty
+    protected Long interactions;
+
+    @JsonProperty("unique_authors")
+    protected Long uniqueAuthors;
+
+    public PylonTaskResultResult() {
+    }
+
+    public PylonTaskAnalysisResult getAnalysis() {
+        return this.analysis;
+    }
+
+    public Long getInteractions() {
+        return this.interactions;
+    }
+
+    public Long getUniqueAuthors() {
+        return this.uniqueAuthors;
+    }
+
+}

--- a/src/test/java/com/datasift/client/examples/TaskApi.java
+++ b/src/test/java/com/datasift/client/examples/TaskApi.java
@@ -5,7 +5,9 @@ import com.datasift.client.FutureData;
 import com.datasift.client.pylon.DataSiftPylonTask;
 import com.datasift.client.pylon.PylonParametersData;
 import com.datasift.client.pylon.PylonQueryParameters;
+import com.datasift.client.pylon.PylonTaskAnalysisResult;
 import com.datasift.client.pylon.PylonTaskAnalysisResultBucket;
+import com.datasift.client.pylon.PylonTaskAnalyzeResponse;
 import com.datasift.client.pylon.PylonTaskParameters;
 import com.datasift.client.pylon.PylonTaskRequest;
 import com.datasift.client.pylon.PylonTaskResult;
@@ -45,7 +47,7 @@ public class TaskApi {
         // build the task to do it against a certain time period
         PylonTaskParameters taskParams = new PylonTaskParameters(queryParams, 1488067200, 1488153600);
         // submit the analysis query
-        FutureData<PylonTaskResult> resultFuture = taskClient.analyze(
+        FutureData<PylonTaskAnalyzeResponse> resultFuture = taskClient.analyze(
                 new PylonTaskRequest(
                         "subscriptionid",
                         taskParams,

--- a/src/test/java/com/datasift/client/examples/TaskApi.java
+++ b/src/test/java/com/datasift/client/examples/TaskApi.java
@@ -1,0 +1,81 @@
+package com.datasift.client.examples;
+
+import com.datasift.client.DataSiftConfig;
+import com.datasift.client.FutureData;
+import com.datasift.client.pylon.DataSiftPylonTask;
+import com.datasift.client.pylon.PylonParametersData;
+import com.datasift.client.pylon.PylonQueryParameters;
+import com.datasift.client.pylon.PylonTaskAnalysisResultBucket;
+import com.datasift.client.pylon.PylonTaskParameters;
+import com.datasift.client.pylon.PylonTaskRequest;
+import com.datasift.client.pylon.PylonTaskResult;
+import com.datasift.client.pylon.PylonTaskResultList;
+
+import java.util.Scanner;
+
+public class TaskApi {
+    private TaskApi() { }
+
+    public static void main(String[] args) {
+        /* Making an API client */
+        // make a client and ensure we're on version 1.4 of the API
+        DataSiftConfig config = new DataSiftConfig("userid", "apikey").versionPrefix("v1.4");
+        // construct the API client
+        DataSiftPylonTask taskClient = new DataSiftPylonTask(config);
+
+        /* Listing */
+        // query 10 tasks
+        PylonTaskResultList resultList = taskClient.get(0, 10).sync();
+        // print out the total number of tasks the API knows about
+        System.out.println("task result count: " + resultList.getCount());
+        // print the ones we queried out in a nice table
+        for (PylonTaskResult task : resultList.getTasks()) {
+            System.out.println("\t" + task.getId() +
+                               "\t" + task.getSubscriptionId() +
+                               "\t" + task.getType() +
+                               "\t" + task.getStatus());
+        }
+
+        /* Doing a new Task */
+        // build up the frequency distribution query we want
+        PylonQueryParameters queryParams = new PylonQueryParameters(
+                "freqDist",
+                new PylonParametersData("li.all.articles.author.member.age", 10)
+        );
+        // build the task to do it against a certain time period
+        PylonTaskParameters taskParams = new PylonTaskParameters(queryParams, 1488067200, 1488153600);
+        // submit the analysis query
+        FutureData<PylonTaskResult> resultFuture = taskClient.analyze(
+                new PylonTaskRequest(
+                        "subscriptionid",
+                        taskParams,
+                        "andi-datasift-java",
+                        "analysis")
+        );
+        // pull the ID out of our submission
+        String analysisId = resultFuture.sync().getId();
+        System.out.println("made request id " + analysisId);
+        Scanner s = new Scanner(System.in);
+        // loop until we have some results, then display them
+        while (true) {
+            System.out.println("press enter when you want to retry");
+            System.out.println(s.nextLine());
+            PylonTaskResult r = taskClient.get(analysisId).sync();
+            System.out.println(r.getStatus());
+            if (r.getStatus().equals("completed")) {
+                System.out.println(r.getResult());
+                System.out.println("interactions: " + r.getResult().getInteractions().toString());
+                System.out.println("unique authors: " + r.getResult().getUniqueAuthors().toString());
+                System.out.println("redacted: " + r.getResult().getAnalysis().getRedacted());
+                System.out.println("results:");
+                for (PylonTaskAnalysisResultBucket bucket : r.getResult().getAnalysis().getResults()) {
+                    System.out.println(
+                            bucket.getKey() + " | " +
+                            bucket.getInteractions() + " | " +
+                            bucket.getUniqueAuthors()
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Make `versionPrefix` on `DataSiftConfig` chainable
* Added a constructor to `PylonParametersData` for `target`+`threshold` as it's a common use case
* Added a new Client for the Task API in `DataSiftPylonTask`
* Implemented `get(id)`, `get(pageNumber, perPage)` and `analyze(query)` for the Task API
* Create all container classes for data that goes in and out of the Task API